### PR TITLE
Created a default.html for consistancy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 _site
+.jekyll-cache

--- a/_includes/default.html
+++ b/_includes/default.html
@@ -1,0 +1,40 @@
+<!DOCTYPE HTML>
+<!--
+    Editorial by HTML5 UP
+    html5up.net | @ajlkn
+    Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
+-->
+<html>
+
+<head>
+    <title>{{ page.title }} - {{ site.title }}</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
+    <!--[if lte IE 8]><script src="assets/js/ie/html5shiv.js"></script><![endif]-->
+    <link rel="stylesheet" href="/assets/css/main.css" />
+    <!--[if lte IE 8]><link rel="stylesheet" href="assets/css/ie8.css" /><![endif]-->
+</head>
+
+<body>
+    <div id="wrapper">
+        <div id="main">
+            <div class="inner">
+                {{ content }}
+            </div>
+        </div>
+    </div>
+    <!-- Scripts -->
+    <script src="/assets/js/jquery.min.js"></script>
+    <script src="/assets/js/jquery.dropotron.min.js"></script>
+    <script src="/assets/js/skel.min.js"></script>
+    <script src="/assets/js/skel-viewport.min.js"></script>
+    <script src="/assets/js/util.js"></script>
+    <!--[if lte IE 8]><script src="/assets/js/ie/respond.min.js"></script><![endif]-->
+    <script src="/assets/js/main.js"></script>
+</body>
+<footer id="footer">
+    <p class="copright">Recipes are public domain. See <a href="/license"> additional license information</a> | Design:
+        <a href="http://html5up.net">HTML5 UP</a></p>
+</footer>
+
+</html>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -19,6 +19,12 @@
     <div id="wrapper">
         <div id="main">
             <div class="inner">
+                <!-- Header -->
+                <header id="header">
+                    <a class="logo" href="/">FOSS Family Recipes</a>
+                    <ul class="icons">
+                    </ul>
+                </header>
                 {{ content }}
             </div>
         </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -25,6 +25,24 @@
                     <ul class="icons">
                     </ul>
                 </header>
+                <div id="sidebar">
+                    <div class="inner">
+                        <nav id="menu">
+                            <header class="major">
+                                <h2>Browse</h2>
+                            </header>
+                            <ul>
+                                <li><a href="/">Home</a></li>
+                                <li><a href="/all-recipes">All Recipes</a></li>
+                                {% assign tags =  site.recipes | map: 'tags' | uniq | sort_natural %}
+                                {% for tag in tags %}
+                                <li><a href="/categories#{{tag | slugify}}">{{tag}}</a></li>
+                                {% endfor %}
+                            </ul>
+                        </nav>
+
+                    </div>
+                </div>
                 {{ content }}
             </div>
         </div>

--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -1,8 +1,7 @@
 ---
 layout: default
 ---
-<!-- Post -->
-
+<!-- Index -->
 <section id="banner">
     <div class="content">
         {{ content }}
@@ -12,21 +11,3 @@ layout: default
         <img src="{{ page.hero }}">
     </span>
 </section>
-<div id="sidebar">
-    <div class="inner">
-        <nav id="menu">
-            <header class="major">
-                <h2>Browse</h2>
-            </header>
-            <ul>
-                <li><a href="/">Home</a></li>
-                <li><a href="/all-recipes">All Recipes</a></li>
-                {% assign tags =  site.recipes | map: 'tags' | uniq | sort_natural%}
-                {% for tag in tags %}
-                <li><a href="/categories#{{tag | slugify}}">{{tag}}</a></li>
-                {% endfor %}
-            </ul>
-        </nav>
-
-    </div>
-</div>

--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -1,45 +1,32 @@
-{% include site_html_start.html %}
-{% include site_header.html %}
-{% include page_start.html %}
-                <!-- Post -->
-                <section id="banner">
-                    <div class="content">
-                    <header>
-                        <h1>{{ page.title }}</h1>
-                    </header>
+---
+layout: default
+---
+<!-- Post -->
 
-                    {{ content }}
-                    </div>
+<section id="banner">
+    <div class="content">
+        {{ content }}
+    </div>
 
-                    <span class="image object">
-                        <img src="{{ page.hero }}">
-                    </span>
-                </section>
+    <span class="image object">
+        <img src="{{ page.hero }}">
+    </span>
+</section>
+<div id="sidebar">
+    <div class="inner">
+        <nav id="menu">
+            <header class="major">
+                <h2>Browse</h2>
+            </header>
+            <ul>
+                <li><a href="/">Home</a></li>
+                <li><a href="/all-recipes">All Recipes</a></li>
+                {% assign tags =  site.recipes | map: 'tags' | uniq | sort_natural%}
+                {% for tag in tags %}
+                <li><a href="/categories#{{tag | slugify}}">{{tag}}</a></li>
+                {% endfor %}
+            </ul>
+        </nav>
 
-                </div>
-                </div>
-
-                <div id="sidebar">
-                    <div class="inner">
-                        <nav id="menu">
-                           <header class="major">
-                                <h2>Browse</h2>
-                            </header>
-                            <ul>
-                                <li><a href="/">Home</a></li>
-                                <li><a href="/all-recipes">All Recipes</a></li>
-                                {% assign tags =  site.recipes | map: 'tags' | join: ','  | split: ',' | uniq %}
-
-                                {% for tag in tags %}
-                                <li><a href="/categories#{{tag | slugify}}">{{tag}}</a></li>
-                                {% endfor %}
-                            </ul>
-                        </nav>
-
-    {% include site_footer.html %}
-                </div>
-
+    </div>
 </div>
-{% include scripts.html %}
-</body>
-</html>

--- a/index.md
+++ b/index.md
@@ -3,13 +3,13 @@ layout: index
 title: FOSS Family Recipes
 hero: /images/potatoes-and-pot.jpg
 ---
-
 <header>
-<p>Free and community-sourced recipes.</p>
+    <h1>{{ page.title }}</h1>
+    <p>Free and community-sourced recipes.</p>
 </header>
 
 <ul class="actions">
-<li><a href="/categories" class="button big">Tags</a></li>
-<li><a href="/all-recipes" class="button big">Browse All</a></li>
-<li><a href="https://github.com/thenaterhood/fossrecipes" class="button big">Github</a></li>
+    <li><a href="/categories" class="button big">Tags</a></li>
+    <li><a href="/all-recipes" class="button big">Browse All</a></li>
+    <li><a href="https://github.com/thenaterhood/fossrecipes" class="button big">Github</a></li>
 </ul>


### PR DESCRIPTION
I noticed the index.html and page.html layouts were using several includes, while breaking the continuity of several tags (several divs were broken). In this commit, I created a default.html template layout that contains the same site_html_start, header, footer, scripts and the sidebar. Index.html would use the default.html layout instead.

This allows:

1. A uniform site construction. All pages (including all recipes) will share the same base template.
2. Site-wide changes will be captured in one file.
3. Maintains template structure